### PR TITLE
appium v2 to v3 migration

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.11'
 
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2023-10-23
+- upgraded dependencies
+- migrated appium client from v2 to v3
+
 ## [0.1.2] - 2023-10-23
 - added accessibility_id locator strategy replacing deprecated windows uiautomation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperiontf"
-version = "0.1.3"
+version = "0.1.4"
 description = "Hyperion Testing Framework"
 authors = ["Oleksiy Bondar <bondaroleksiyandriyovich@gmail.com>"]
 license = "Apache 2.0 License"
@@ -9,11 +9,11 @@ readme = "README.md"
 [tool.poetry.dependencies]
 requests="^2.31.0"
 python = "^3.11"
-jsonschema = "^4.18.6"
-selenium = "^4.11.2"
-Appium-Python-Client = "^2.11.1"
+jsonschema = "^4.19.1"
+selenium = "^4.14.0"
+Appium-Python-Client = "^3.1.0"
 playwright = "^1.36.0"
-webdriver_manager="^3.9.1"
+webdriver_manager="^4.0.1"
 
 
 [build-system]

--- a/src/hyperiontf/ui/appium/page.py
+++ b/src/hyperiontf/ui/appium/page.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from appium import webdriver
+
 import copy
 
 from hyperiontf.configuration import config
@@ -44,7 +45,34 @@ class Page:
         desired_cap.pop("automation")
         automation_name = desired_cap["automationName"]
 
-        return Page(webdriver.Remote(hub_url, desired_cap), automation_name)
+        return Page(
+            webdriver.Remote(hub_url, options=Page.dict_to_options(desired_cap)),
+            automation_name,
+        )
+
+    @staticmethod
+    def dict_to_options(desired_caps):
+        automation_name = desired_caps["automationName"]
+
+        if automation_name == "ios":
+            from appium.options.ios import XCUITestOptions
+
+            options = XCUITestOptions()
+        if automation_name == "uiautomator2":
+            from appium.options.android import UiAutomator2Options
+
+            options = UiAutomator2Options()
+        if automation_name == "Mac2":
+            from appium.options.mac import Mac2Options
+
+            options = Mac2Options()
+        if automation_name == "windows":
+            from appium.options.windows import WindowsOptions
+
+            options = WindowsOptions()
+
+        options.load_capabilities(desired_caps)
+        return options
 
     @property
     @map_exception

--- a/tests/demo_test.py
+++ b/tests/demo_test.py
@@ -104,6 +104,7 @@
 #         "platformName": "Mac",
 #         "deviceName": "Mac",
 #         "bundleId": "com.apple.calculator",
+#         "remote_url": "http://10.211.55.2:4723"
 #     }
 #     page = DesktopCalculator.launch_app(caps)
 #     actual_test_case(page)


### PR DESCRIPTION


## Description
starting from appium 3.* capabilities dictionary no longer supported it must be converted to options object

## Changes Summary

- appium v2 to v3 migration
- dependencies upgrade


## Checklist
- [x] Self-review: I have performed a self-review of my own code.
- [x] Documentation: I have updated related documentation.
- [x] Tests: New functionality is covered by tests, or related tests have been updated.

---

⚠️ Note: This pull request is subject to checks by GitHub Actions. It will not be merged until all checks pass successfully.
