### PR TITLE
Fix JSON schema matching for arrays and add configurable CLI shell startup (args/env)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,27 @@ It is important to acknowledge that versions prior to v1.0.0 are considered to b
 
 From its first version, our framework has included a dedicated REST client equipped with extensive, built-in logging features, alongside a UI harness that simplifies page object creation. This harness supports a unified API compatible with Selenium, Appium, and Playwright, ensuring a seamless and efficient testing process.
 
-## [0.8.00] - 2026-05-08
+## [0.7.04] - 2026-05-13
+
+### Fixed
+
+- JSON Schema validation now works consistently for array-like values (`list`, `tuple`, `set`) in addition to dictionaries.
+- Resolved schema validation duplication across array/dict assertion strategies by moving shared behavior into a common schema-capable strategy layer.
+- Fixed CLI action-prompt handling edge cases where prompt/command parsing could cut output incorrectly in interactive shell sessions.
+
+### Added
+
+- New shell startup controls for CLI-based clients:
+  - `shell_args`: pass shell command-line arguments at process start.
+  - `env`: pass environment variables into spawned shell sessions.
+
+### Tests
+
+- Added real-shell integration coverage for CLI client startup customization:
+  - verifies environment variable passthrough;
+  - verifies shell argument passthrough.
+
+## [0.7.03] - 2026-05-08
 
 ### Added
 

--- a/docs/reference/public-api/expect.md
+++ b/docs/reference/public-api/expect.md
@@ -353,7 +353,7 @@ Checks whether the dict contains / does not contain a value.
 
 **Contract**
 
-Validates the dict-like subject against a schema supported by Hyperion’s schema validation.
+Validates dict and array-like subjects against a JSON Schema.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperiontf"
-version = "0.7.03"
+version = "0.7.04"
 description = "Hyperion Testing Framework"
 authors = ["Oleksiy Bondar <bondaroleksiyandriyovich@gmail.com>"]
 license = "Apache-2.0"

--- a/src/hyperiontf/api/rest_client/response.py
+++ b/src/hyperiontf/api/rest_client/response.py
@@ -77,7 +77,7 @@ class Response:
         :return: The HTTP status message.
         :rtype: str
         """
-        return self.response.reason
+        return self.response.reason or ""
 
     @property
     def raw_body(self) -> str:

--- a/src/hyperiontf/assertions/expect.py
+++ b/src/hyperiontf/assertions/expect.py
@@ -8,6 +8,7 @@ from hyperiontf.assertions.strategy.numeric_strategy import NumericStrategy
 from hyperiontf.assertions.strategy.string_strategy import StringStrategy
 from hyperiontf.assertions.strategy.array_strategy import ArrayStrategy
 from hyperiontf.assertions.strategy.dict_strategy import DictStrategy
+from hyperiontf.assertions.strategy.json_schemed_strategy import JSONSchemedStrategy
 from hyperiontf.assertions.strategy.color_strategy import ColorStrategy
 from hyperiontf.assertions.strategy.filesystem_strategy import FileSystemStrategy
 from hyperiontf.assertions.strategy.image_strategy import ImageStrategy
@@ -1096,13 +1097,12 @@ class Expect:
         return self.strategy.not_to_contain_value(value)  # type: ignore
 
     @auto_log
-    @type_check(supported_strategies=[DictStrategy])
+    @type_check(supported_strategies=[JSONSchemedStrategy])
     def to_match_schema(self, schema: Union[dict, str]) -> ExpectationResult:
         """
-        Asserts that the actual dictionary matches a specified JSON schema. This method is crucial for validating
-        complex data structures, ensuring that dictionaries conform to predefined formats, structures, and type
-        requirements as defined by the JSON schema. It is particularly useful for API response validation, configuration
-        data verification, and ensuring data integrity across various application components.
+        Asserts that the actual value matches a specified JSON schema. This method is supported for
+        dictionary and array-like subjects and is useful for validating structured data contracts in
+        API responses, configuration payloads, and other JSON-like content.
 
         Args:
             schema (Union[dict, str]): The JSON schema to validate against, provided either as a dictionary representing
@@ -1110,7 +1110,7 @@ class Expect:
 
         Returns:
             ExpectationResult: An object representing the result of the schema validation, detailing whether the actual
-                               dictionary matches the specified JSON schema, including the validation outcome and any
+                               value matches the specified JSON schema, including the validation outcome and any
                                schema validation errors encountered.
 
         Note:

--- a/src/hyperiontf/assertions/strategy/array_strategy.py
+++ b/src/hyperiontf/assertions/strategy/array_strategy.py
@@ -1,9 +1,9 @@
-from .default_strategy import DefaultStrategy
+from .json_schemed_strategy import JSONSchemedStrategy
 from hyperiontf.assertions.expectation_result import ExpectationResult
 from .decorators import with_array_diff
 
 
-class ArrayStrategy(DefaultStrategy):
+class ArrayStrategy(JSONSchemedStrategy):
     types = [list, set, tuple]
 
     @with_array_diff

--- a/src/hyperiontf/assertions/strategy/dict_strategy.py
+++ b/src/hyperiontf/assertions/strategy/dict_strategy.py
@@ -1,12 +1,9 @@
-from .default_strategy import DefaultStrategy
+from .json_schemed_strategy import JSONSchemedStrategy
 from hyperiontf.assertions.expectation_result import ExpectationResult
 from .decorators import with_dict_diff
 
-import jsonschema
-import json
 
-
-class DictStrategy(DefaultStrategy):
+class DictStrategy(JSONSchemedStrategy):
     types = [dict]
 
     @with_dict_diff
@@ -161,40 +158,3 @@ class DictStrategy(DefaultStrategy):
             method="not_to_contain_value",
             human_readable_description=human_readable_description,
         )
-
-    def to_match_schema(self, schema) -> ExpectationResult:
-        """
-        Validates the actual dictionary against the provided JSON Schema. The schema can be
-        provided directly as a dictionary representing the JSON Schema or as a string path
-        to a JSON Schema file.
-
-        Args:
-            schema (Union[dict, str]): The JSON Schema to validate against, either as a dictionary
-                                       or a string path to a JSON Schema file.
-
-        Returns:
-            ExpectationResult: The result of the JSON Schema validation, including a human-readable
-                               description of the action performed. If the validation fails, the 'diff'
-                               property of the result will contain the validation error message.
-        """
-        if isinstance(schema, str):
-            # Load the JSON Schema from file if a string is provided
-            with open(schema, "r") as schema_file:
-                schema = json.load(schema_file)
-
-        message = "Validate dictionary against the JSON Schema."
-        result = ExpectationResult(
-            result=True,
-            actual_value=self.actual_value,
-            expected_value=schema,
-            method="to_match_schema",
-            human_readable_description=message,
-        )
-
-        try:
-            jsonschema.validate(instance=self.actual_value, schema=schema)
-        except jsonschema.exceptions.ValidationError as e:
-            result.result = False
-            result.diff = e.message
-
-        return result

--- a/src/hyperiontf/assertions/strategy/json_schemed_strategy.py
+++ b/src/hyperiontf/assertions/strategy/json_schemed_strategy.py
@@ -8,6 +8,8 @@ from .default_strategy import DefaultStrategy
 
 
 class JSONSchemedStrategy(DefaultStrategy):
+    types = [dict, list, set, tuple]
+
     def to_match_schema(self, schema) -> ExpectationResult:
         """
         Validates the actual value against the provided JSON Schema. The schema can be

--- a/src/hyperiontf/assertions/strategy/json_schemed_strategy.py
+++ b/src/hyperiontf/assertions/strategy/json_schemed_strategy.py
@@ -1,0 +1,45 @@
+import json
+
+import jsonschema
+
+from hyperiontf.assertions.expectation_result import ExpectationResult
+
+from .default_strategy import DefaultStrategy
+
+
+class JSONSchemedStrategy(DefaultStrategy):
+    def to_match_schema(self, schema) -> ExpectationResult:
+        """
+        Validates the actual value against the provided JSON Schema. The schema can be
+        provided directly as a dictionary representing the JSON Schema or as a string path
+        to a JSON Schema file.
+
+        Args:
+            schema (Union[dict, str]): The JSON Schema to validate against, either as a dictionary
+                                       or a string path to a JSON Schema file.
+
+        Returns:
+            ExpectationResult: The result of the JSON Schema validation, including a human-readable
+                               description of the action performed. If the validation fails, the 'diff'
+                               property of the result will contain the validation error message.
+        """
+        if isinstance(schema, str):
+            with open(schema, "r") as schema_file:
+                schema = json.load(schema_file)
+
+        message = "Validate value against the JSON Schema."
+        result = ExpectationResult(
+            result=True,
+            actual_value=self.actual_value,
+            expected_value=schema,
+            method="to_match_schema",
+            human_readable_description=message,
+        )
+
+        try:
+            jsonschema.validate(instance=self.actual_value, schema=schema)
+        except jsonschema.exceptions.ValidationError as e:
+            result.result = False
+            result.diff = e.message
+
+        return result

--- a/src/hyperiontf/cli/base_shell.py
+++ b/src/hyperiontf/cli/base_shell.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Optional, Union
+from typing import Optional, Union, List, Dict, Callable
 
 from hyperiontf.logging import getLogger
 from hyperiontf.typing import (
@@ -39,19 +39,31 @@ class BaseShell:
     :param tool: The tool to be used for the session (e.g., 'bash', 'sh', 'zsh', 'cmd', 'powershell', or other CLI tools).
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        shell: Optional[str] = None,
+        shell_args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        disable_prompt_shortening: bool = True,
+        cmd_line_matcher: Optional[Callable[[str, str, Optional[str]], bool]] = None,
+    ):
         """
         Initializes the BaseShell for a specific tool.
 
         Subclasses should implement the session initialization logic for the required tool or shell.
         """
-        self.output_cache = []
-        self.exit_code = None
+        self.output_cache: List[str] = []
+        self.exit_code: Optional[int] = None
 
-        self.action_prompt = None
-        self.last_cmd = None
+        self.action_prompt: Optional[str] = None
+        self.last_cmd: Optional[str] = None
 
-        self.source = self.__class__.__name__
+        self.source = shell if shell else self.__class__.__name__
+        self._shell_executable = shell
+        self.shell_args = shell_args or []
+        self.env = env or {}
+        self.disable_prompt_shortening = disable_prompt_shortening
+        self.cmd_line_matcher = cmd_line_matcher
 
         self.logger = getLogger(LoggerSource.CLI)
 
@@ -113,23 +125,46 @@ class BaseShell:
         :param line: The line to check.
         :return: True if the line is a command or prompt, False otherwise.
         """
-        # Pattern to match different shell prompt and command formats
-        # - Full command only
-        # - Prompt + command
-        # - Shortened prompt due to path length
-        # % .*? %
-        # Example pattern: <path/end$ <cmd>
-
-        # Define a regex pattern to match prompt variations
-        pattern = r"^\s*<.*?(\$|\#)\s*"  # Matches <path$ or <path#
-
         if not self.last_cmd:
             return False
-        # Check if the line matches the last command or one of the patterns
-        return line == self.last_cmd or (
-            self.last_cmd in line
-            and (bool(re.search(pattern, line)) or self.action_prompt in line)
-        )
+
+        if line == self.last_cmd:
+            return True
+
+        if self.last_cmd not in line:
+            return False
+
+        if self._is_shortened_prompt_line(line):
+            return True
+
+        return self._contains_action_prompt(line)
+
+    @staticmethod
+    def _is_shortened_prompt_line(line: str) -> bool:
+        pattern = r"^\s*<.*?(\$|\#)\s*"
+        return bool(re.search(pattern, line))
+
+    def _contains_action_prompt(self, line: str) -> bool:
+        prompt = self.action_prompt
+        if prompt is None:
+            return False
+        return prompt in line
+
+    def _is_posix_shell_prompt(self) -> bool:
+        shell_name = str(self._shell_executable or self.source).lower()
+        return shell_name in {"sh", "bash", "zsh"}
+
+    def _compose_spawn_argv(self) -> List[str]:
+        return [self._shell_executable or self.source, *self.shell_args]
+
+    def _compose_spawn_env(self) -> Dict[str, str]:
+        spawn_env = os.environ.copy()
+        spawn_env.update(self.env)
+        if self.disable_prompt_shortening and self._is_posix_shell_prompt():
+            spawn_env.setdefault("PS1", "hyperion$ ")
+            spawn_env.setdefault("PROMPT", "hyperion$ ")
+            spawn_env.setdefault("COLUMNS", "1024")
+        return spawn_env
 
     def _clear_cache(self):
         """

--- a/src/hyperiontf/cli/base_shell.py
+++ b/src/hyperiontf/cli/base_shell.py
@@ -105,11 +105,17 @@ class BaseShell:
         if data == self.action_prompt:
             return
 
+        self._process_cache_lines(data)
+
+    def _process_cache_lines(self, data):
         lines = data.split(self.line_separator)
         for line in lines:
             line = line.strip()
 
             if self._is_cmd_line(line):
+                trailing_output = self._extract_trailing_output_after_command(line)
+                if trailing_output:
+                    self.output_cache.append(trailing_output)
                 self.last_cmd = None
                 continue
 
@@ -149,6 +155,14 @@ class BaseShell:
         if prompt is None:
             return False
         return prompt in line
+
+    def _extract_trailing_output_after_command(self, line: str) -> str:
+        if not self.last_cmd:
+            return ""
+        if self.last_cmd not in line:
+            return ""
+        trailing_output = line.split(self.last_cmd, 1)[1].strip()
+        return trailing_output
 
     def _is_posix_shell_prompt(self) -> bool:
         shell_name = str(self._shell_executable or self.source).lower()
@@ -205,8 +219,26 @@ class BaseShell:
         which is the marker used to indicate when a command has finished executing.
         """
         data = self._read_output_buffer()
-        self.action_prompt = data.split(self.line_separator)[-1].strip()
+        self.action_prompt = self._extract_action_prompt(data)
         self._log_debug(f"Action prompt is:\n{self.action_prompt}")
+
+    def detect_action_prompt(self):
+        """
+        Detects and normalizes the tool's action prompt.
+
+        Sends a newline first so the shell prints a fresh prompt, then captures it.
+        """
+        self.send_keys("")
+        self._detect_action_prompt()
+
+    @staticmethod
+    def _extract_action_prompt(data: str) -> str:
+        lines = [line.strip() for line in data.splitlines() if line.strip()]
+        if not lines:
+            return ""
+        prompt = lines[-1]
+        prompt = re.sub(r"\s+", " ", prompt).strip()
+        return prompt
 
     def _write(self, data: str):
         """
@@ -399,10 +431,15 @@ class BaseShell:
         and converts the remaining value into an integer representing the exit code.
         """
         output = self._read_output_buffer()
-        output = output.replace(self.line_separator, "")
-        output = output.replace(self.exit_code_cmd, "")
-        output = output.replace(self.action_prompt, "")
-        self.exit_code = int(output)
+        self.exit_code = self._extract_exit_code(output)
+
+    def _extract_exit_code(self, output: str) -> int:
+        # Extract the last standalone integer token from the chunk.
+        # This is robust when prompt/command/result are merged in one line.
+        matches = re.findall(r"(?<!\S)-?\d+(?!\S)", output)
+        if not matches:
+            raise ValueError(f"Failed to parse exit code from output: {repr(output)}")
+        return int(matches[-1])
 
     def _remove_action_prompt_from_output(self):
         """

--- a/src/hyperiontf/cli/cli_client.py
+++ b/src/hyperiontf/cli/cli_client.py
@@ -1,6 +1,7 @@
 from .base_shell import BaseShell, DEFAULT_EXIT_CODE_COMMAND
 
 from ptyprocess import PtyProcess
+from typing import Optional
 from hyperiontf.logging import getLogger
 from hyperiontf.typing import (
     LoggerSource,
@@ -39,16 +40,32 @@ class CLIClient(BaseShell):
     :param shell: The shell to be used for the session (default: 'bash').
     """
 
-    def __init__(self, shell="bash"):
+    def __init__(
+        self,
+        shell="bash",
+        shell_args=None,
+        env=None,
+        disable_prompt_shortening: bool = True,
+        cmd_line_matcher=None,
+    ):
         """
         Initializes the CLIClient for a specific shell.
 
         :param shell: The shell to be used (e.g., 'bash', 'sh', 'zsh', 'cmd', 'powershell').
         """
-        super().__init__()
+        shell_args = self._normalize_shell_args(
+            shell, shell_args, disable_prompt_shortening
+        )
 
-        self.source = shell
-        self.process = None
+        super().__init__(
+            shell=shell,
+            shell_args=shell_args,
+            env=env,
+            disable_prompt_shortening=disable_prompt_shortening,
+            cmd_line_matcher=cmd_line_matcher,
+        )
+
+        self.process: Optional[PtyProcess] = None
         self.exit_code_cmd = self._fetch_exit_code_cmd()
 
         self.start_session()
@@ -68,7 +85,10 @@ class CLIClient(BaseShell):
         """
         try:
             # Start a new shell session using PtyProcess
-            self.process = PtyProcess.spawn([self.shell])
+            self.process = PtyProcess.spawn(
+                self._compose_spawn_argv(),
+                env=self._compose_spawn_env(),
+            )
             self._log_action(f"Spawning a new {self.shell} session.")
             time.sleep(
                 config.cli.command_registration_time
@@ -80,6 +100,25 @@ class CLIClient(BaseShell):
                 f"Failed to start shell session: {str(e)}", CommandExecutionException
             )
 
+    @staticmethod
+    def _normalize_shell_args(shell, shell_args, disable_prompt_shortening):
+        normalized_shell_args = list(shell_args or [])
+        if not disable_prompt_shortening:
+            return normalized_shell_args
+        defaults_by_shell = {
+            "bash": ["--noprofile", "--norc"],
+            "zsh": ["-f"],
+        }
+        for default_arg in defaults_by_shell.get(shell, []):
+            if default_arg not in normalized_shell_args:
+                normalized_shell_args.append(default_arg)
+        return normalized_shell_args
+
+    def _require_process(self) -> PtyProcess:
+        if self.process is None:
+            raise CommandExecutionException("Shell session is not started.")
+        return self.process
+
     def _read_output_buffer(self) -> str:
         """
         Reads and decodes the current buffer from the shell session.
@@ -89,7 +128,7 @@ class CLIClient(BaseShell):
 
         :return: The decoded output from the shell.
         """
-        data = self.process.read().decode().strip()
+        data = self._require_process().read().decode().strip()
         self._log_debug(f"Reading output chunk:\n{data}")
         return data
 
@@ -103,7 +142,7 @@ class CLIClient(BaseShell):
         :param data: The string to write to the shell session.
         """
         self._log_debug(f"Writing data chunk:\n{data}")
-        self.process.write(f"{data}\n".encode("utf-8"))
+        self._require_process().write(f"{data}\n".encode("utf-8"))
         time.sleep(config.cli.command_registration_time)
 
     def _fetch_exit_code_cmd(self):

--- a/src/hyperiontf/cli/ssh_client.py
+++ b/src/hyperiontf/cli/ssh_client.py
@@ -1,5 +1,6 @@
 from .base_shell import BaseShell
 import paramiko
+import shlex
 from hyperiontf.typing import CommandExecutionException
 from hyperiontf.configuration.config import config
 import time
@@ -81,9 +82,11 @@ class SSHClient(BaseShell):
                 config.cli.ssh_connection_explicit_wait
             )  # Wait for shell to initialize
 
-            self._prepare_prompt_settings()
+            self._activate_requested_shell()
 
             self._detect_action_prompt()
+
+            self._prepare_prompt_settings()
 
         except Exception as e:
             self._log_error(
@@ -98,14 +101,26 @@ class SSHClient(BaseShell):
         self._connect_using_password()
 
     def _invoke_shell_with_environment(self):
+        if not self.env:
+            return self.ssh_client.invoke_shell()
         try:
-            return self.ssh_client.invoke_shell(environment=self._compose_spawn_env())
+            return self.ssh_client.invoke_shell(environment=self.env)
         except TypeError:
             return self.ssh_client.invoke_shell()
 
     def _prepare_prompt_settings(self):
         if self.disable_prompt_shortening and self._is_posix_shell_prompt():
             self._apply_remote_prompt_settings()
+            self.action_prompt = "hyperion$"
+
+    def _activate_requested_shell(self):
+        if not self.shell:
+            return
+        shell_executable = self._shell_executable or "bash"
+        shell_argv = [shell_executable, *self.shell_args]
+        shell_command = "exec " + shlex.join(shell_argv)
+        self.shell.send(f"{shell_command}\n")
+        time.sleep(config.cli.command_registration_time)
 
     def _connect_using_private_key(self):
         self.ssh_client.connect(
@@ -167,7 +182,13 @@ class SSHClient(BaseShell):
     def _apply_remote_prompt_settings(self):
         if not self.shell:
             return
-        self.shell.send("export PS1='hyperion$ '\n")
-        self.shell.send("export PROMPT='hyperion$ '\n")
+        self.shell.send("export PS1='hyperion$'\n")
+        self.shell.send("export PROMPT='hyperion$'\n")
         self.shell.send("export COLUMNS=1024\n")
+        self.shell.send("\n")
         time.sleep(config.cli.command_registration_time)
+        try:
+            # Drain one noisy chunk produced by prompt reconfiguration.
+            self._read_output_buffer()
+        except Exception:
+            pass

--- a/src/hyperiontf/cli/ssh_client.py
+++ b/src/hyperiontf/cli/ssh_client.py
@@ -26,8 +26,26 @@ class SSHClient(BaseShell):
     :param port: The SSH port (default: 22).
     """
 
-    def __init__(self, host, user, password=None, private_key=None, port=22):
-        super().__init__()
+    def __init__(
+        self,
+        host,
+        user,
+        password=None,
+        private_key=None,
+        port=22,
+        shell="bash",
+        shell_args=None,
+        env=None,
+        disable_prompt_shortening: bool = True,
+        cmd_line_matcher=None,
+    ):
+        super().__init__(
+            shell=shell,
+            shell_args=shell_args,
+            env=env,
+            disable_prompt_shortening=disable_prompt_shortening,
+            cmd_line_matcher=cmd_line_matcher,
+        )
 
         self.host = host
         self.user = user
@@ -55,17 +73,15 @@ class SSHClient(BaseShell):
         """
         try:
             self._log_action(f"Connecting to {self.host} as {self.user}.")
-            if self.private_key:
-                self._connect_using_private_key()
-            else:
-                self._connect_using_password()
+            self._connect()
             self._log_action("SSH session established.")
 
-            # Start an interactive shell
-            self.shell = self.ssh_client.invoke_shell()
+            self.shell = self._invoke_shell_with_environment()
             time.sleep(
                 config.cli.ssh_connection_explicit_wait
             )  # Wait for shell to initialize
+
+            self._prepare_prompt_settings()
 
             self._detect_action_prompt()
 
@@ -74,6 +90,22 @@ class SSHClient(BaseShell):
                 f"Failed to establish SSH connection: {str(e)}",
                 CommandExecutionException,
             )
+
+    def _connect(self):
+        if self.private_key:
+            self._connect_using_private_key()
+            return
+        self._connect_using_password()
+
+    def _invoke_shell_with_environment(self):
+        try:
+            return self.ssh_client.invoke_shell(environment=self._compose_spawn_env())
+        except TypeError:
+            return self.ssh_client.invoke_shell()
+
+    def _prepare_prompt_settings(self):
+        if self.disable_prompt_shortening and self._is_posix_shell_prompt():
+            self._apply_remote_prompt_settings()
 
     def _connect_using_private_key(self):
         self.ssh_client.connect(
@@ -131,3 +163,11 @@ class SSHClient(BaseShell):
         if self.ssh_client:
             self._log_action("Terminating SSH session.")
             self.ssh_client.close()
+
+    def _apply_remote_prompt_settings(self):
+        if not self.shell:
+            return
+        self.shell.send("export PS1='hyperion$ '\n")
+        self.shell.send("export PROMPT='hyperion$ '\n")
+        self.shell.send("export COLUMNS=1024\n")
+        time.sleep(config.cli.command_registration_time)

--- a/tests/common/base_shell_unit_test.py
+++ b/tests/common/base_shell_unit_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from hyperiontf.cli.base_shell import BaseShell
+from hyperiontf.cli.cli_client import CLIClient
+
+
+class DummyShell(BaseShell):
+    def start_session(self):
+        pass
+
+    def _write(self, data: str):
+        pass
+
+    def _read_output_buffer(self) -> str:
+        return ""
+
+
+@pytest.mark.CLI
+def test_compose_spawn_env_respects_external_env_overrides():
+    shell = DummyShell(
+        shell="bash",
+        env={"HYPERION_TEST_ENV": "enabled"},
+        disable_prompt_shortening=True,
+    )
+    env = shell._compose_spawn_env()
+
+    assert env["HYPERION_TEST_ENV"] == "enabled"
+
+
+@pytest.mark.CLI
+def test_compose_spawn_argv_includes_shell_args():
+    shell = DummyShell(shell="bash", shell_args=["--noprofile", "--norc"])
+    assert shell._compose_spawn_argv() == ["bash", "--noprofile", "--norc"]
+
+
+@pytest.mark.CLI
+def test_cli_client_adds_default_shell_args_for_bash_when_prompt_shortening_disabled(
+    monkeypatch,
+):
+    captured = {}
+
+    class FakeProcess:
+        @staticmethod
+        def read():
+            return b"hyperion$ "
+
+        @staticmethod
+        def write(_data):
+            return None
+
+        @staticmethod
+        def terminate():
+            return None
+
+    def fake_spawn(
+        argv,
+        cwd=None,
+        env=None,
+        echo=True,
+        preexec_fn=None,
+        dimensions=(24, 80),
+        pass_fds=(),
+    ):
+        captured["argv"] = argv
+        captured["env"] = env
+        return FakeProcess()
+
+    monkeypatch.setattr("hyperiontf.cli.cli_client.PtyProcess.spawn", fake_spawn)
+
+    client = CLIClient(
+        shell="bash",
+        env={"HYPERION_TEST_ENV": "enabled"},
+        disable_prompt_shortening=True,
+    )
+    try:
+        assert captured["argv"][:3] == ["bash", "--noprofile", "--norc"]
+        assert captured["env"]["HYPERION_TEST_ENV"] == "enabled"
+    finally:
+        client.quit()

--- a/tests/common/cli_client_test.py
+++ b/tests/common/cli_client_test.py
@@ -2,6 +2,7 @@ import pytest
 from hyperiontf import CLIClient, expect
 from hyperiontf.executors.pytest import fixture
 import os
+import tempfile
 from hyperiontf.typing import CommandExecutionTimeoutException
 
 
@@ -16,6 +17,40 @@ def cli_client(request):
     request.addfinalizer(client.quit)
 
     yield client
+
+
+@fixture(log=False)
+def cli_client_with_custom_env(request):
+    client = CLIClient(shell="bash", env={"HYPERION_TEST_ENV": "from_env"})
+    request.addfinalizer(client.quit)
+    return client
+
+
+@fixture(log=False)
+def cli_client_with_rcfile(request):
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as rc_file:
+        rc_file.write("export HYPERION_FROM_RC=from_rc\n")
+        rc_path = rc_file.name
+
+    client = CLIClient(
+        shell="bash",
+        shell_args=["--rcfile", rc_path],
+        disable_prompt_shortening=False,
+    )
+    request.addfinalizer(client.quit)
+    request.addfinalizer(lambda: os.unlink(rc_path))
+    return client
+
+
+@fixture(log=False)
+def cli_client_with_env_passthrough(request):
+    client = CLIClient(
+        shell="bash",
+        env={"HYPERION_TEST_ENV2": "env_ok"},
+        disable_prompt_shortening=False,
+    )
+    request.addfinalizer(client.quit)
+    return client
 
 
 @pytest.mark.CLI
@@ -74,3 +109,26 @@ def test_command_execution_with_timeout(cli_client):
     """
     with pytest.raises(CommandExecutionTimeoutException):
         cli_client.execute("sleep 3", timeout=2)
+
+
+@pytest.mark.CLI
+@pytest.mark.ExecuteCommand
+def test_cli_client_passes_custom_env_to_real_shell(cli_client_with_custom_env):
+    cli_client_with_custom_env.execute("echo $HYPERION_TEST_ENV")
+    cli_client_with_custom_env.assert_output_contains("from_env")
+
+
+@pytest.mark.CLI
+@pytest.mark.ExecuteCommand
+def test_cli_client_passes_shell_args_to_real_shell(cli_client_with_rcfile):
+    cli_client_with_rcfile.execute("echo $HYPERION_FROM_RC")
+    cli_client_with_rcfile.assert_output_contains("from_rc")
+
+
+@pytest.mark.CLI
+@pytest.mark.ExecuteCommand
+def test_cli_client_passes_env_to_real_shell_with_custom_args(
+    cli_client_with_env_passthrough,
+):
+    cli_client_with_env_passthrough.execute("echo $HYPERION_TEST_ENV2")
+    cli_client_with_env_passthrough.assert_output_contains("env_ok")


### PR DESCRIPTION
Description:

This pull request addresses schema-validation and CLI shell-session robustness issues, and adds startup customization controls for CLI-based shells. It also adds/updates tests and changelog entries for 0.7.04.


Changes Summary:

-Refactored JSON schema assertion logic into a shared strategy layer so both dict and array-like subjects are supported consistently (Default -> JSONSchemed -> Array/Dict).
- Added CLI shell startup customization support (shell_args, env) across CLI-based clients and wired these into process/session startup.
- Added/updated real-shell and unit test coverage for CLI args/env passthrough, plus release notes in CHANGELOG.md for 0.7.04.


Checklist:

[x] Self-review: I have performed a self-review of my own code.
[x] Documentation: I have updated related documentation.
[x] Tests: New functionality is covered by tests, or related tests have been updated.

⚠️ Note: This pull request is subject to checks by GitHub Actions. It will not be merged until all checks pass successfully.